### PR TITLE
Trigger stdlib dependency update workflow only for master branch

### DIFF
--- a/.github/workflows/stdlib-workflow-trigger.yml
+++ b/.github/workflows/stdlib-workflow-trigger.yml
@@ -1,4 +1,4 @@
-name: Stdlib dependency update
+name: Stdlib Dependency Update
 
 on:
   push:

--- a/.github/workflows/stdlib-workflow-trigger.yml
+++ b/.github/workflows/stdlib-workflow-trigger.yml
@@ -2,9 +2,11 @@ name: Stdlib Dependency Update
 
 on:
   push:
+    branches: 
+      - master
     paths:
-    - 'build.gradle'
-    - 'gradle.properties'
+      - 'build.gradle'
+      - 'gradle.properties'
 
 jobs:
   trigger-workflow:


### PR DESCRIPTION
## Purpose
Trigger stdlib dependency update workflow only when `build.gradle` file or `gradle.properties` file is updated in the master branch
