### PR TITLE
Fix multi-value attribute encoding for non-ASCII characters

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ldap"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Ballerina"]
 export=["ldap"]
 keywords = ["ldap"]
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ldap-native"
-version = "1.3.0"
-path = "../native/build/libs/ldap-native-1.3.0.jar"
+version = "1.3.1-SNAPSHOT"
+path = "../native/build/libs/ldap-native-1.3.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.unboundid"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -65,7 +65,7 @@ scope = "testOnly"
 [[package]]
 org = "ballerina"
 name = "ldap"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -32,7 +32,7 @@ public isolated client class Client {
     } external;
 
     # Creates an entry in a directory server.
-    # 
+    #
     # ```ballerina
     # anydata user = {
     #   "objectClass": "user",
@@ -41,7 +41,7 @@ public isolated client class Client {
     # };
     # ldap:LdapResponse result = check ldapClient->add(userDN, user);
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry
     # + entry - The information to add
     # + return - A `ldap:Error` if the operation fails or `ldap:LdapResponse` if successfully created
@@ -50,11 +50,11 @@ public isolated client class Client {
     } external;
 
     # Removes an entry in a directory server.
-    # 
+    #
     # ```ballerina
     # ldap:LdapResponse result = check ldapClient->delete(userDN);
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry to remove
     # + return - A `ldap:Error` if the operation fails or `ldap:LdapResponse` if successfully removed
     remote isolated function delete(string dN) returns LdapResponse|Error = @java:Method {
@@ -62,7 +62,7 @@ public isolated client class Client {
     } external;
 
     # Updates information of an entry.
-    # 
+    #
     # ```ballerina
     # anydata user = {
     #   "sn": "User",
@@ -71,7 +71,7 @@ public isolated client class Client {
     # };
     # ldap:LdapResponse result = check ldapClient->modify(userDN, user);
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry
     # + entry - The information to update
     # + return - A `ldap:Error` if the operation fails or `LdapResponse` if successfully updated
@@ -80,11 +80,11 @@ public isolated client class Client {
     } external;
 
     # Renames an entry in a directory server.
-    # 
+    #
     # ```ballerina
     # ldap:LdapResponse modifyDN = check ldapClient->modifyDn(userDN, "CN=Test User2", true);
     # ```
-    # 
+    #
     # + currentDn - The current distinguished name of the entry
     # + newRdn - The new relative distinguished name
     # + deleteOldRdn - A boolean value to determine whether to delete the old RDN
@@ -95,11 +95,11 @@ public isolated client class Client {
     } external;
 
     # Determines whether a given entry has a specified attribute value.
-    # 
+    #
     # ```ballerina
     # boolean compare = check ldapClient->compare(userDN, "givenName", "New User");
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry
     # + attributeName - The name of the target attribute for which the comparison is to be performed
     # + assertionValue - The assertion value to verify within the entry
@@ -110,11 +110,11 @@ public isolated client class Client {
     } external;
 
     # Gets information of an entry.
-    # 
+    #
     # ```ballerina
     # anydata value = check ldapClient->getEntry(userDN);
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry
     # + targetType - Default parameter use to infer the user specified type
     # + return - An entry result with the given type or else `ldap:Error`
@@ -124,28 +124,28 @@ public isolated client class Client {
     } external;
 
     # Returns a list of entries that match the given search parameters.
-    # 
+    #
     # ```ballerina
     # anydata[] value = check ldapClient->searchWithType("DC=ldap,DC=com", "(givenName=New User)", ldap:SUB);
     # ```
-    # 
+    #
     # + baseDn - The base distinguished name of the entry
     # + filter - The filter to be used in the search
     # + scope - The scope of the search
     # + targetType - Default parameter use to infer the user specified type
     # + return - An array of entries with the given type or else `ldap:Error`
-    remote isolated function searchWithType(string baseDn, string filter, 
-                                            SearchScope scope, typedesc<record{}[]> targetType = <>)
+    remote isolated function searchWithType(string baseDn, string filter,
+            SearchScope scope, typedesc<record {}[]> targetType = <>)
         returns targetType|Error = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;
 
     # Returns a record containing search result entries and references that match the given search parameters.
-    # 
+    #
     # ```ballerina
     # ldap:SearchResult value = check ldapClient->search("DC=ldap,DC=windows", "(givenName=New User)", ldap:SUB);
     # ```
-    # 
+    #
     # + baseDn - The base distinguished name of the entry
     # + filter - The filter to be used in the search
     # + scope - The scope of the search
@@ -156,21 +156,21 @@ public isolated client class Client {
     } external;
 
     # Unbinds from the server and closes the LDAP connection. 
-    # 
+    #
     # ```ballerina
     # ldapClient->close();
     # ```
-    # 
+    #
     remote isolated function close() = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;
 
     # Determines whether the client is connected to the server.
-    # 
+    #
     # ```ballerina
     # boolean isConnected = ldapClient->isConnected();
     # ```
-    # 
+    #
     # + return - A boolean value indicating the connection status
     remote isolated function isConnected() returns boolean = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -23,369 +23,371 @@ configurable string password = ?;
 configurable string userDN = ?;
 
 final Client ldap = check new ({
-   hostName,
-   port,
-   domainName,
-   password
+    hostName,
+    port,
+    domainName,
+    password
 });
 
 function validateClient(Client ldapClient) returns Client|error {
-   boolean isConnected = ldapClient->isConnected();
-   return isConnected ? ldapClient : new ({
-      hostName,
-      port,
-      domainName,
-      password
-   });
+    boolean isConnected = ldapClient->isConnected();
+    return isConnected ? ldapClient : new ({
+            hostName,
+            port,
+            domainName,
+            password
+        });
 }
 
 @test:Config {}
 public function testAddUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   record {|AttributeType...;|} user = {
-       "objectClass": ["top", "person"],
-       "sn": "User",
-       "cn": "User"
-   };
-   LdapResponse addResponse = check ldapClient->add("cn=User,dc=mycompany,dc=com", user);
-   test:assertEquals(addResponse.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    record {|AttributeType...;|} user = {
+        "objectClass": ["top", "person"],
+        "sn": "User",
+        "cn": "User"
+    };
+    LdapResponse addResponse = check ldapClient->add("cn=User,dc=mycompany,dc=com", user);
+    test:assertEquals(addResponse.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testAddUser]
+    dependsOn: [testAddUser]
 }
 public function testAddSecondaryUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   record {|AttributeType...;|} user = {
-       "objectClass": ["top", "person"],
-       "sn": "New User",
-       "cn": "New User"
-   };
-   LdapResponse addResult = check ldapClient->add("CN=New User,dc=mycompany,dc=com", user);
-   test:assertEquals(addResult.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    record {|AttributeType...;|} user = {
+        "objectClass": ["top", "person"],
+        "sn": "New User",
+        "cn": "New User"
+    };
+    LdapResponse addResult = check ldapClient->add("CN=New User,dc=mycompany,dc=com", user);
+    test:assertEquals(addResult.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testGetUser]
+    dependsOn: [testGetUser]
 }
 public function testDeleteUserHavingManager() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->delete("CN=New User,dc=mycompany,dc=com");
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->delete("CN=New User,dc=mycompany,dc=com");
+    test:assertEquals(response.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testDeleteUserHavingManager]
+    dependsOn: [testDeleteUserHavingManager]
 }
 public function testDeleteUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->delete("CN=User,dc=mycompany,dc=com");
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->delete("CN=User,dc=mycompany,dc=com");
+    test:assertEquals(response.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testAddSecondaryUser]
+    dependsOn: [testAddSecondaryUser]
 }
 public function testAddAlreadyExistingUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   Entry user = {
-       "objectClass": ["top", "person"],
-       "sn": "New User",
-       "cn": "New User"
-   };
-   LdapResponse|Error response = ldapClient->add("CN=New User,dc=mycompany,dc=com", user);
-   test:assertTrue(response is Error);
-   if response is Error {
-       ErrorDetails errorDetails = response.detail();
-       test:assertEquals(errorDetails.resultCode, "ENTRY ALREADY EXISTS");
-   }
+    Client ldapClient = check validateClient(ldap);
+    Entry user = {
+        "objectClass": ["top", "person"],
+        "sn": "New User",
+        "cn": "New User"
+    };
+    LdapResponse|Error response = ldapClient->add("CN=New User,dc=mycompany,dc=com", user);
+    test:assertTrue(response is Error);
+    if response is Error {
+        ErrorDetails errorDetails = response.detail();
+        test:assertEquals(errorDetails.resultCode, "ENTRY ALREADY EXISTS");
+    }
 }
 
 @test:Config {
-   dependsOn: [testAddAlreadyExistingUser]
+    dependsOn: [testAddAlreadyExistingUser]
 }
 public function testUpdateUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   record {|AttributeType...;|} user = {
-       "sn": "Updated User"
-   };
-   LdapResponse response = check ldapClient->modify(userDN, user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    record {|AttributeType...;|} user = {
+        "sn": "Updated User"
+    };
+    LdapResponse response = check ldapClient->modify(userDN, user);
+    test:assertEquals(response.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testUpdateUserWithNullValues]
+    dependsOn: [testUpdateUserWithNullValues]
 }
 public function testGetUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   UserConfig value = check ldapClient->getEntry(userDN);
-   test:assertEquals(value?.sn, "Updated User");
+    Client ldapClient = check validateClient(ldap);
+    UserConfig value = check ldapClient->getEntry(userDN);
+    test:assertEquals(value?.sn, "Updated User");
 }
 
 @test:Config {}
 public function testInvalidClient() returns error? {
-   Client|Error ldapClient = new ({
-       hostName: "111.111.11.111",
-       port: port,
-       domainName: domainName,
-       password: password
-   });
-   test:assertTrue(ldapClient is Error);
+    Client|Error ldapClient = new ({
+        hostName: "111.111.11.111",
+        port: port,
+        domainName: domainName,
+        password: password
+    });
+    test:assertTrue(ldapClient is Error);
 }
 
 @test:Config {}
 public function testInvalidDomainInClient() {
-   Client|Error ldapClient = new ({
-       hostName: hostName,
-       port: port,
-       domainName: "invalid@ad.invalid",
-       password: password
-   });
-   test:assertTrue(ldapClient is Error);
+    Client|Error ldapClient = new ({
+        hostName: hostName,
+        port: port,
+        domainName: "invalid@ad.invalid",
+        password: password
+    });
+    test:assertTrue(ldapClient is Error);
 }
 
 @test:Config {}
 public function testGetInvalidUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   UserConfig|Error value = ldapClient->getEntry("CN=Invalid User,dc=mycompany,dc=com");
-   test:assertTrue(value is Error);
+    Client ldapClient = check validateClient(ldap);
+    UserConfig|Error value = ldapClient->getEntry("CN=Invalid User,dc=mycompany,dc=com");
+    test:assertTrue(value is Error);
 }
 
 @test:Config {
-   dependsOn: [testUpdateUser]
+    dependsOn: [testUpdateUser]
 }
 public function testUpdateUserWithNullValues() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->modify(userDN, updateUser);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->modify(userDN, updateUser);
+    test:assertEquals(response.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testAddUserWithNullValues() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testCompareAttributeValues() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   boolean compare = check ldapClient->compare("CN=Test User1,dc=mycompany,dc=com", "sn", "Timothy");
-   test:assertEquals(compare, true);
+    boolean compare = check ldapClient->compare("CN=Test User1,dc=mycompany,dc=com", "sn", "Timothy");
+    test:assertEquals(compare, true);
 
-   LdapResponse modifyDN = check ldapClient->modifyDn("CN=Test User1,dc=mycompany,dc=com", "CN=Test User2", true);
-   test:assertEquals(modifyDN.resultCode, SUCCESS);
+    LdapResponse modifyDN = check ldapClient->modifyDn("CN=Test User1,dc=mycompany,dc=com", "CN=Test User2", true);
+    test:assertEquals(modifyDN.resultCode, SUCCESS);
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User2,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User2,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testSearchWithType() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
-   test:assertEquals(value.length(), 1);
-   test:assertEquals(value[0].objectClass, ["person", "top"]);
+    UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertEquals(value.length(), 1);
+    test:assertEquals(value[0].objectClass, ["person", "top"]);
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testSearchUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   SearchResult value = check ldapClient->search("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
-   test:assertEquals(value.resultCode, SUCCESS);
-   test:assertEquals((<Entry[]>value.entries).length(), 1);
-   test:assertEquals((<Entry[]>value.entries)[0]["objectClass"], ["person", "top"]);
-   test:assertTrue(value?.searchReferences is ());
+    SearchResult value = check ldapClient->search("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertEquals(value.resultCode, SUCCESS);
+    test:assertEquals((<Entry[]>value.entries).length(), 1);
+    test:assertEquals((<Entry[]>value.entries)[0]["objectClass"], ["person", "top"]);
+    test:assertTrue(value?.searchReferences is ());
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testSearchNonExistingUsers() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   SearchResult|Error value = ldapClient->search("dc=mycompany,dc=com", "(givenName=Non existent)", SUB);
-   test:assertTrue(value is Error);
-   if value is Error {
-       ErrorDetails errorDetails = value.detail();
-       test:assertEquals(errorDetails.resultCode, OTHER);
-   }
+    SearchResult|Error value = ldapClient->search("dc=mycompany,dc=com", "(givenName=Non existent)", SUB);
+    test:assertTrue(value is Error);
+    if value is Error {
+        ErrorDetails errorDetails = value.detail();
+        test:assertEquals(errorDetails.resultCode, OTHER);
+    }
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testAddingUserWithClosedClient() returns error? {
-   Client ldapClient1 = check new ({
-       hostName: hostName,
-       port: port,
-       domainName: domainName,
-       password: password
-   });
-   ldapClient1->close();
-   boolean isConnected = ldapClient1->isConnected();
-   test:assertTrue(!isConnected);
-   LdapResponse|Error response = ldapClient1->add("CN=Test User12,dc=mycompany,dc=com", user);
-   test:assertTrue(response is Error);
-   if response is Error {
-       ErrorDetails errorDetails = response.detail();
-       test:assertEquals(errorDetails.resultCode, OTHER);
-   }
+    Client ldapClient1 = check new ({
+        hostName: hostName,
+        port: port,
+        domainName: domainName,
+        password: password
+    });
+    ldapClient1->close();
+    boolean isConnected = ldapClient1->isConnected();
+    test:assertTrue(!isConnected);
+    LdapResponse|Error response = ldapClient1->add("CN=Test User12,dc=mycompany,dc=com", user);
+    test:assertTrue(response is Error);
+    if response is Error {
+        ErrorDetails errorDetails = response.detail();
+        test:assertEquals(errorDetails.resultCode, OTHER);
+    }
 }
 
 @test:Config {}
 public function testModifyingUserWithClosedClient() returns error? {
-   Client ldapClient1 = check new ({
-       hostName: hostName,
-       port: port,
-       domainName: domainName,
-       password: password
-   });
-   ldapClient1->close();
-   boolean isConnected = ldapClient1->isConnected();
-   test:assertTrue(!isConnected);
-   LdapResponse|Error response = ldapClient1->modify(userDN, updateUser);
-   test:assertTrue(response is Error);
-   if response is Error {
-       ErrorDetails errorDetails = response.detail();
-       test:assertEquals(errorDetails.resultCode, OTHER);
-   }
+    Client ldapClient1 = check new ({
+        hostName: hostName,
+        port: port,
+        domainName: domainName,
+        password: password
+    });
+    ldapClient1->close();
+    boolean isConnected = ldapClient1->isConnected();
+    test:assertTrue(!isConnected);
+    LdapResponse|Error response = ldapClient1->modify(userDN, updateUser);
+    test:assertTrue(response is Error);
+    if response is Error {
+        ErrorDetails errorDetails = response.detail();
+        test:assertEquals(errorDetails.resultCode, OTHER);
+    }
 }
 
 @test:Config {}
 public function testModifyDN() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   LdapResponse modifyDN = check ldapClient->modifyDn("CN=Test User1,dc=mycompany,dc=com", "CN=Test User2", true);
-   test:assertEquals(modifyDN.resultCode, SUCCESS);
+    LdapResponse modifyDN = check ldapClient->modifyDn("CN=Test User1,dc=mycompany,dc=com", "CN=Test User2", true);
+    test:assertEquals(modifyDN.resultCode, SUCCESS);
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User2,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User2,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testModifyDnInNonExistingUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse|Error modifyDN = ldapClient->modifyDn("CN=Non Existing User,dc=mycompany,dc=com", "CN=Test User2", true);
-   test:assertTrue(modifyDN is Error);
-   if modifyDN is Error {
-       ErrorDetails errorDetails = modifyDN.detail();
-       test:assertEquals(errorDetails.resultCode, NO_SUCH_OBJECT);
-   }
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse|Error modifyDN = ldapClient->modifyDn("CN=Non Existing User,dc=mycompany,dc=com", "CN=Test User2", true);
+    test:assertTrue(modifyDN is Error);
+    if modifyDN is Error {
+        ErrorDetails errorDetails = modifyDN.detail();
+        test:assertEquals(errorDetails.resultCode, NO_SUCH_OBJECT);
+    }
 }
 
 @test:Config {}
 public function testSearchWithInvalidType() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   record {|string id;|}[]|Error value = ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
-   test:assertTrue(value is Error);
-   test:assertEquals((<Error>value).message(), "{ballerina}ConversionError");
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    record {|string id;|}[]|Error value = ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertTrue(value is Error);
+    test:assertEquals((<Error>value).message(), "{ballerina}ConversionError");
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
-@test:Config{}
+@test:Config {}
 public function testTlsConnection() returns error? {
-   ClientSecureSocket clientSecureSocket = {
-      cert: "tests/resources/server/certs/server.crt",
-      enable: true
-   };
+    ClientSecureSocket clientSecureSocket = {
+        cert: "tests/resources/server/certs/server.crt",
+        enable: true
+    };
 
-   Client ldapClient =  check new ({
-      port: 636,
-      hostName,
-      password,
-      domainName,
-      clientSecureSocket
-   });
+    Client ldapClient = check new ({
+        port: 636,
+        hostName,
+        password,
+        domainName,
+        clientSecureSocket
+    });
 
-   boolean isConnected = ldapClient->isConnected();
-   test:assertTrue(isConnected);
+    boolean isConnected = ldapClient->isConnected();
+    test:assertTrue(isConnected);
 }
 
-@test:Config{}
+@test:Config {}
 public function testTlsConnectionWithInvalidCert() returns error? {
-   ClientSecureSocket clientSecureSocket = {
-      cert: "tests/resources/server/certs/invalid.crt",
-      enable: true
-   };
+    ClientSecureSocket clientSecureSocket = {
+        cert: "tests/resources/server/certs/invalid.crt",
+        enable: true
+    };
 
-   Client|Error ldapClient =  new ({
-      port: 636,
-      hostName,
-      password,
-      domainName,
-      clientSecureSocket
-   });
+    Client|Error ldapClient = new ({
+        port: 636,
+        hostName,
+        password,
+        domainName,
+        clientSecureSocket
+    });
 
-   test:assertTrue(ldapClient is Error);
+    test:assertTrue(ldapClient is Error);
 }
 
-@test:Config{}
+@test:Config {}
 public function testTlsConnectionWithTrustStore() returns error? {
-   ClientSecureSocket clientSecureSocket = {
-         cert: {
-               path: "tests/resources/server/certs/truststore.p12",
-               password: "password"
-         }
-   };
+    ClientSecureSocket clientSecureSocket = {
+        cert: {
+            path: "tests/resources/server/certs/truststore.p12",
+            password: "password"
+        }
+    };
 
-   Client ldapClient =  check new ({
-      port: 636,
-      hostName,
-      password,
-      domainName,
-      clientSecureSocket
-   });
+    Client ldapClient = check new ({
+        port: 636,
+        hostName,
+        password,
+        domainName,
+        clientSecureSocket
+    });
 
-   boolean isConnected = ldapClient->isConnected();
-   test:assertTrue(isConnected);
+    boolean isConnected = ldapClient->isConnected();
+    test:assertTrue(isConnected);
 }
 
 @test:Config {}
 public function testMultiValueAttributeWithNonAscii() returns error? {
-   Client ldapClient = check validateClient(ldap);
+    Client ldapClient = check validateClient(ldap);
 
-   Entry userWithNonAscii = {
-       "objectClass": ["top", "person"],
-       "sn": "Müller",
-       "cn": "Test User Non-ASCII",
-       "description": ["日本語テスト", "Ελληνικά", "中文测试"]
-   };
-   LdapResponse addResponse = check ldapClient->add("CN=Test User Non-ASCII,dc=mycompany,dc=com", userWithNonAscii);
-   test:assertEquals(addResponse.resultCode, SUCCESS);
+    Entry userWithNonAscii = {
+        "objectClass": ["top", "person"],
+        "sn": "Müller",
+        "cn": "Test User Non-ASCII",
+        "description": ["日本語テスト", "Ελληνικά", "中文测试"]
+    };
+    LdapResponse addResponse = check ldapClient->add("CN=Test User Non-ASCII,dc=mycompany,dc=com", userWithNonAscii);
+    test:assertEquals(addResponse.resultCode, SUCCESS);
 
-   Entry value = check ldapClient->getEntry("CN=Test User Non-ASCII,dc=mycompany,dc=com");
-   anydata description = value["description"];
-   if description !is string[] {
-      test:assertFail("Expected description to be of type string[]");
-   }
+    Entry value = check ldapClient->getEntry("CN=Test User Non-ASCII,dc=mycompany,dc=com");
+    anydata description = value["description"];
+    if description !is string[] {
+        test:assertFail("Expected description to be of type string[]");
+    }
 
-   test:assertEquals(description, ["日本語テスト", "Ελληνικά", "中文测试"], "Multi-value attribute with non-ASCII characters did not match expected values");
-   LdapResponse delete = check ldapClient->delete("CN=Test User Non-ASCII,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    // Expected descriptions are Base64 encoded values
+    string[] expectedDescriptions = ["5pel5pys6Kqe44OG44K544OI", "zpXOu867zrfOvc65zrrOrA==", "5Lit5paH5rWL6K+V"];
+    test:assertEquals(description, expectedDescriptions, "Multi-value attribute with non-ASCII characters did not match expected values");
+    LdapResponse delete = check ldapClient->delete("CN=Test User Non-ASCII,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -365,3 +365,28 @@ public function testTlsConnectionWithTrustStore() returns error? {
    boolean isConnected = ldapClient->isConnected();
    test:assertTrue(isConnected);
 }
+
+@test:Config {}
+public function testMultiValueAttributeWithNonAscii() returns error? {
+   Client ldapClient = check validateClient(ldap);
+
+   Entry userWithNonAscii = {
+       "objectClass": ["top", "person"],
+       "sn": "Müller",
+       "cn": "Test User Non-ASCII",
+       "description": ["日本語テスト", "Ελληνικά", "中文测试"]
+   };
+   LdapResponse addResponse = check ldapClient->add("CN=Test User Non-ASCII,dc=mycompany,dc=com", userWithNonAscii);
+   test:assertEquals(addResponse.resultCode, SUCCESS);
+
+   Entry value = check ldapClient->getEntry("CN=Test User Non-ASCII,dc=mycompany,dc=com");
+   anydata description = value["description"];
+   if description !is string[] {
+      test:assertFail("Expected description to be of type string[]");
+   }
+
+   test:assertEquals(description.length(), 3, msg = "Expected 3 description values");
+   
+   LdapResponse delete = check ldapClient->delete("CN=Test User Non-ASCII,dc=mycompany,dc=com");
+   test:assertEquals(delete.resultCode, SUCCESS);
+}

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -385,8 +385,7 @@ public function testMultiValueAttributeWithNonAscii() returns error? {
       test:assertFail("Expected description to be of type string[]");
    }
 
-   test:assertEquals(description.length(), 3, msg = "Expected 3 description values");
-   
+   test:assertEquals(description, ["日本語テスト", "Ελληνικά", "中文测试"], "Multi-value attribute with non-ASCII characters did not match expected values");
    LdapResponse delete = check ldapClient->delete("CN=Test User Non-ASCII,dc=mycompany,dc=com");
    test:assertEquals(delete.resultCode, SUCCESS);
 }

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -19,8 +19,8 @@ import ballerina/crypto;
 # Provides a set of configurations to connect with a directory server.
 #
 # + hostName - The host name of the Active Directory server
-# + port - The port of the Active Directory server
-# + domainName - The domain name of the Active Directory
+# + port - The port of the ldap server
+# + domainName - The domain name of the ldap server
 # + password - The password of the Active Directory
 # + clientSecureSocket - Client secure socket configurations
 public type ConnectionConfig record {|

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -19,8 +19,8 @@ import ballerina/crypto;
 # Provides a set of configurations to connect with a directory server.
 #
 # + hostName - The host name of the Active Directory server
-# + port -  The port of the Active Directory server
-# + domainName -  The domain name of the Active Directory
+# + port - The port of the Active Directory server
+# + domainName - The domain name of the Active Directory
 # + password - The password of the Active Directory
 # + clientSecureSocket - Client secure socket configurations
 public type ConnectionConfig record {|
@@ -30,7 +30,6 @@ public type ConnectionConfig record {|
     string password;
     ClientSecureSocket clientSecureSocket?;
 |};
-
 
 # Provides configurations for facilitating secure communication with a remote ldap server.
 #
@@ -110,7 +109,9 @@ public enum SearchScope {
 public type AttributeType boolean|int|float|decimal|string|string[];
 
 # LDAP entry type.
-public type Entry record{|AttributeType...;|};
+public type Entry record {|
+    AttributeType...;
+|};
 
 # A record for an entry that represents a person.
 #

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -18,10 +18,10 @@ import ballerina/crypto;
 
 # Provides a set of configurations to connect with a directory server.
 #
-# + hostName - The host name of the Active Directory server
-# + port - The port of the ldap server
-# + domainName - The domain name of the ldap server
-# + password - The password of the Active Directory
+# + hostName - The host name of the LDAP server
+# + port - The port of the LDAP server
+# + domainName - The domain name of the LDAP server
+# + password - The password of the LDAP server
 # + clientSecureSocket - Client secure socket configurations
 public type ConnectionConfig record {|
     string hostName;
@@ -31,7 +31,7 @@ public type ConnectionConfig record {|
     ClientSecureSocket clientSecureSocket?;
 |};
 
-# Provides configurations for facilitating secure communication with a remote ldap server.
+# Provides configurations for facilitating secure communication with a remote LDAP server.
 #
 # + enable - Enable SSL validation
 # + cert - Configurations associated with `crypto:TrustStore` or single certificate file that the client trusts

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,11 @@
+# Change Log
+This file contains all the notable changes done to the Ballerina LDAP package through the releases.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to 
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+
+- [Fix multi-value LDAP attributes with non-ASCII characters returning only the first encoded value](https://github.com/ballerina-platform/ballerina-library/issues/8562)

--- a/native/src/main/java/io/ballerina/lib/ldap/Client.java
+++ b/native/src/main/java/io/ballerina/lib/ldap/Client.java
@@ -435,8 +435,19 @@ public final class Client {
     static void processAttribute(Attribute attribute, BMap<BString, Object> entry) {
         BString attributeName = StringUtils.fromString(attribute.getName());
         if (attribute.needsBase64Encoding()) {
-            String readableString = encodeAttributeValue(attribute);
-            entry.put(attributeName, StringUtils.fromString(readableString));
+            byte[][] valueByteArrays = attribute.getValueByteArrays();
+            if (valueByteArrays == null || valueByteArrays.length == 0) {
+                return;
+            }
+            if (valueByteArrays.length > 1) {
+                String[] encodedValues = encodeAttributeValues(attribute.getName(), valueByteArrays);
+                BString[] stringValues = Arrays.stream(encodedValues)
+                        .map(StringUtils::fromString).toArray(BString[]::new);
+                entry.put(attributeName, ValueCreator.createArrayValue(stringValues));
+            } else {
+                String readableString = encodeAttributeValue(attribute.getName(), valueByteArrays[0]);
+                entry.put(attributeName, StringUtils.fromString(readableString));
+            }
         } else {
             if (attribute.getValues().length > 1) {
                 String[] values = attribute.getValues();
@@ -448,9 +459,14 @@ public final class Client {
         }
     }
 
-    private static String encodeAttributeValue(Attribute attribute) {
-        byte[] valueBytes = attribute.getValueByteArray();
-        return switch (attribute.getName()) {
+    private static String[] encodeAttributeValues(String attributeName, byte[][] valueByteArrays) {
+        return Arrays.stream(valueByteArrays)
+                .map(valueBytes -> encodeAttributeValue(attributeName, valueBytes))
+                .toArray(String[]::new);
+    }
+
+    private static String encodeAttributeValue(String attributeName, byte[] valueBytes) {
+        return switch (attributeName) {
             case OBJECT_GUID -> convertObjectGUIDToString(valueBytes);
             case OBJECT_SID -> convertObjectSidToString(valueBytes);
             default -> Base64.encode(valueBytes);


### PR DESCRIPTION
# Description

When an LDAP attribute has multiple values containing non-ASCII characters, only the first value was returned. The `processAttribute` method was using `attribute.getValueByteArray()` (singular) which only returns the first value's byte array, ignoring subsequent values.

Fixes https://github.com/ballerina-platform/ballerina-library/issues/8562

One line release note: 
- Fixed multi-value LDAP attributes with non-ASCII characters returning only the first encoded value

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Added `testMultiValueAttributeWithNonAscii` test that creates an entry with multi-value `description` attribute containing Japanese, Greek, and Chinese characters, then verifies all 3 values are returned

**Test Configuration**:
* Ballerina Version: SwanLake Update 12
* Operating System: Linux
* Java SDK: 21

# Checklist:
- [x] Added tests
- [x] Updated changelog

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
