### PR TITLE
Add selective attribute retrieval support

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ldap"
-version = "1.3.1"
+version = "1.4.0"
 authors = ["Ballerina"]
 export=["ldap"]
 keywords = ["ldap"]
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ldap-native"
-version = "1.3.1-SNAPSHOT"
-path = "../native/build/libs/ldap-native-1.3.1-SNAPSHOT.jar"
+version = "1.4.0-SNAPSHOT"
+path = "../native/build/libs/ldap-native-1.4.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.unboundid"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ldap"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Ballerina"]
 export=["ldap"]
 keywords = ["ldap"]
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ldap-native"
-version = "1.3.0"
-path = "../native/build/libs/ldap-native-1.3.0.jar"
+version = "1.3.1-SNAPSHOT"
+path = "../native/build/libs/ldap-native-1.3.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.unboundid"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -65,7 +65,7 @@ scope = "testOnly"
 [[package]]
 org = "ballerina"
 name = "ldap"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -65,7 +65,7 @@ scope = "testOnly"
 [[package]]
 org = "ballerina"
 name = "ldap"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -116,10 +116,10 @@ public isolated client class Client {
     # ```
     #
     # + dN - The distinguished name of the entry
-    # + attributes - Optional array of attribute names to retrieve. If not provided, all attributes are retrieved
+    # + attributes - Optional array of attribute names to retrieve. If not provided, attributes are determined based on the target type
     # + targetType - Default parameter use to infer the user specified type
     # + return - An entry result with the given type or else `ldap:Error`
-    remote isolated function getEntry(string dN, string[]? attributes = (), typedesc<anydata> targetType = <>)
+    remote isolated function getEntry(string dN, string[]? attributes = (), typedesc<Entry> targetType = <>)
         returns targetType|Error = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;
@@ -133,10 +133,11 @@ public isolated client class Client {
     # + baseDn - The base distinguished name of the entry
     # + filter - The filter to be used in the search
     # + scope - The scope of the search
-    # + targetType - Default parameter use to infer the user specified type. The attributes to retrieve are automatically determined from the record type fields
+    # + attributes - Optional array of attribute names to retrieve. If not provided, attributes are determined based on the target type
+    # + targetType - Default parameter use to infer the user specified type
     # + return - An array of entries with the given type or else `ldap:Error`
     remote isolated function searchWithType(string baseDn, string filter,
-            SearchScope scope, typedesc<record {}[]> targetType = <>)
+            SearchScope scope, string[]? attributes = (), typedesc<record {}[]> targetType = <>)
         returns targetType|Error = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -119,7 +119,7 @@ public isolated client class Client {
     # + attributes - Optional array of attribute names to retrieve. If not provided, attributes are determined based on the target type
     # + targetType - Default parameter use to infer the user specified type
     # + return - An entry result with the given type or else `ldap:Error`
-    remote isolated function getEntry(string dN, string[]? attributes = (), typedesc<Entry> targetType = <>)
+    remote isolated function getEntry(string dN, string[]? attributes = (), typedesc<anydata> targetType = <>)
         returns targetType|Error = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -32,7 +32,7 @@ public isolated client class Client {
     } external;
 
     # Creates an entry in a directory server.
-    # 
+    #
     # ```ballerina
     # anydata user = {
     #   "objectClass": "user",
@@ -41,7 +41,7 @@ public isolated client class Client {
     # };
     # ldap:LdapResponse result = check ldapClient->add(userDN, user);
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry
     # + entry - The information to add
     # + return - A `ldap:Error` if the operation fails or `ldap:LdapResponse` if successfully created
@@ -50,11 +50,11 @@ public isolated client class Client {
     } external;
 
     # Removes an entry in a directory server.
-    # 
+    #
     # ```ballerina
     # ldap:LdapResponse result = check ldapClient->delete(userDN);
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry to remove
     # + return - A `ldap:Error` if the operation fails or `ldap:LdapResponse` if successfully removed
     remote isolated function delete(string dN) returns LdapResponse|Error = @java:Method {
@@ -62,7 +62,7 @@ public isolated client class Client {
     } external;
 
     # Updates information of an entry.
-    # 
+    #
     # ```ballerina
     # anydata user = {
     #   "sn": "User",
@@ -71,7 +71,7 @@ public isolated client class Client {
     # };
     # ldap:LdapResponse result = check ldapClient->modify(userDN, user);
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry
     # + entry - The information to update
     # + return - A `ldap:Error` if the operation fails or `LdapResponse` if successfully updated
@@ -80,11 +80,11 @@ public isolated client class Client {
     } external;
 
     # Renames an entry in a directory server.
-    # 
+    #
     # ```ballerina
     # ldap:LdapResponse modifyDN = check ldapClient->modifyDn(userDN, "CN=Test User2", true);
     # ```
-    # 
+    #
     # + currentDn - The current distinguished name of the entry
     # + newRdn - The new relative distinguished name
     # + deleteOldRdn - A boolean value to determine whether to delete the old RDN
@@ -95,11 +95,11 @@ public isolated client class Client {
     } external;
 
     # Determines whether a given entry has a specified attribute value.
-    # 
+    #
     # ```ballerina
     # boolean compare = check ldapClient->compare(userDN, "givenName", "New User");
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry
     # + attributeName - The name of the target attribute for which the comparison is to be performed
     # + assertionValue - The assertion value to verify within the entry
@@ -110,67 +110,69 @@ public isolated client class Client {
     } external;
 
     # Gets information of an entry.
-    # 
+    #
     # ```ballerina
     # anydata value = check ldapClient->getEntry(userDN);
     # ```
-    # 
+    #
     # + dN - The distinguished name of the entry
+    # + attributes - Optional array of attribute names to retrieve. If not provided, all attributes are retrieved
     # + targetType - Default parameter use to infer the user specified type
     # + return - An entry result with the given type or else `ldap:Error`
-    remote isolated function getEntry(string dN, typedesc<anydata> targetType = <>)
+    remote isolated function getEntry(string dN, string[]? attributes = (), typedesc<anydata> targetType = <>)
         returns targetType|Error = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;
 
     # Returns a list of entries that match the given search parameters.
-    # 
+    #
     # ```ballerina
     # anydata[] value = check ldapClient->searchWithType("DC=ldap,DC=com", "(givenName=New User)", ldap:SUB);
     # ```
-    # 
+    #
     # + baseDn - The base distinguished name of the entry
     # + filter - The filter to be used in the search
     # + scope - The scope of the search
-    # + targetType - Default parameter use to infer the user specified type
+    # + targetType - Default parameter use to infer the user specified type. The attributes to retrieve are automatically determined from the record type fields
     # + return - An array of entries with the given type or else `ldap:Error`
-    remote isolated function searchWithType(string baseDn, string filter, 
-                                            SearchScope scope, typedesc<record{}[]> targetType = <>)
+    remote isolated function searchWithType(string baseDn, string filter,
+            SearchScope scope, typedesc<record {}[]> targetType = <>)
         returns targetType|Error = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;
 
     # Returns a record containing search result entries and references that match the given search parameters.
-    # 
+    #
     # ```ballerina
     # ldap:SearchResult value = check ldapClient->search("DC=ldap,DC=windows", "(givenName=New User)", ldap:SUB);
     # ```
-    # 
+    #
     # + baseDn - The base distinguished name of the entry
     # + filter - The filter to be used in the search
     # + scope - The scope of the search
+    # + attributes - Optional array of attribute names to retrieve. If not provided, all attributes are retrieved
     # + return - An `ldap:SearchResult` if successful, or else `ldap:Error`
-    remote isolated function search(string baseDn, string filter, SearchScope scope)
+    remote isolated function search(string baseDn, string filter, SearchScope scope, string[]? attributes = ())
         returns SearchResult|Error = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;
 
     # Unbinds from the server and closes the LDAP connection. 
-    # 
+    #
     # ```ballerina
     # ldapClient->close();
     # ```
-    # 
+    #
     remote isolated function close() = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"
     } external;
 
     # Determines whether the client is connected to the server.
-    # 
+    #
     # ```ballerina
     # boolean isConnected = ldapClient->isConnected();
     # ```
-    # 
+    #
     # + return - A boolean value indicating the connection status
     remote isolated function isConnected() returns boolean = @java:Method {
         'class: "io.ballerina.lib.ldap.Client"

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -23,345 +23,480 @@ configurable string password = ?;
 configurable string userDN = ?;
 
 final Client ldap = check new ({
-   hostName,
-   port,
-   domainName,
-   password
+    hostName,
+    port,
+    domainName,
+    password
 });
 
 function validateClient(Client ldapClient) returns Client|error {
-   boolean isConnected = ldapClient->isConnected();
-   return isConnected ? ldapClient : new ({
-      hostName,
-      port,
-      domainName,
-      password
-   });
+    boolean isConnected = ldapClient->isConnected();
+    return isConnected ? ldapClient : new ({
+            hostName,
+            port,
+            domainName,
+            password
+        });
 }
 
 @test:Config {}
 public function testAddUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   record {|AttributeType...;|} user = {
-       "objectClass": ["top", "person"],
-       "sn": "User",
-       "cn": "User"
-   };
-   LdapResponse addResponse = check ldapClient->add("cn=User,dc=mycompany,dc=com", user);
-   test:assertEquals(addResponse.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    record {|AttributeType...;|} user = {
+        "objectClass": ["top", "person"],
+        "sn": "User",
+        "cn": "User"
+    };
+    LdapResponse addResponse = check ldapClient->add("cn=User,dc=mycompany,dc=com", user);
+    test:assertEquals(addResponse.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testAddUser]
+    dependsOn: [testAddUser]
 }
 public function testAddSecondaryUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   record {|AttributeType...;|} user = {
-       "objectClass": ["top", "person"],
-       "sn": "New User",
-       "cn": "New User"
-   };
-   LdapResponse addResult = check ldapClient->add("CN=New User,dc=mycompany,dc=com", user);
-   test:assertEquals(addResult.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    record {|AttributeType...;|} user = {
+        "objectClass": ["top", "person"],
+        "sn": "New User",
+        "cn": "New User"
+    };
+    LdapResponse addResult = check ldapClient->add("CN=New User,dc=mycompany,dc=com", user);
+    test:assertEquals(addResult.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testGetUser]
+    dependsOn: [testGetUser]
 }
 public function testDeleteUserHavingManager() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->delete("CN=New User,dc=mycompany,dc=com");
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->delete("CN=New User,dc=mycompany,dc=com");
+    test:assertEquals(response.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testDeleteUserHavingManager]
+    dependsOn: [testDeleteUserHavingManager]
 }
 public function testDeleteUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->delete("CN=User,dc=mycompany,dc=com");
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->delete("CN=User,dc=mycompany,dc=com");
+    test:assertEquals(response.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testAddSecondaryUser]
+    dependsOn: [testAddSecondaryUser]
 }
 public function testAddAlreadyExistingUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   Entry user = {
-       "objectClass": ["top", "person"],
-       "sn": "New User",
-       "cn": "New User"
-   };
-   LdapResponse|Error response = ldapClient->add("CN=New User,dc=mycompany,dc=com", user);
-   test:assertTrue(response is Error);
-   if response is Error {
-       ErrorDetails errorDetails = response.detail();
-       test:assertEquals(errorDetails.resultCode, "ENTRY ALREADY EXISTS");
-   }
+    Client ldapClient = check validateClient(ldap);
+    Entry user = {
+        "objectClass": ["top", "person"],
+        "sn": "New User",
+        "cn": "New User"
+    };
+    LdapResponse|Error response = ldapClient->add("CN=New User,dc=mycompany,dc=com", user);
+    test:assertTrue(response is Error);
+    if response is Error {
+        ErrorDetails errorDetails = response.detail();
+        test:assertEquals(errorDetails.resultCode, "ENTRY ALREADY EXISTS");
+    }
 }
 
 @test:Config {
-   dependsOn: [testAddAlreadyExistingUser]
+    dependsOn: [testAddAlreadyExistingUser]
 }
 public function testUpdateUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   record {|AttributeType...;|} user = {
-       "sn": "Updated User"
-   };
-   LdapResponse response = check ldapClient->modify(userDN, user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    record {|AttributeType...;|} user = {
+        "sn": "Updated User"
+    };
+    LdapResponse response = check ldapClient->modify(userDN, user);
+    test:assertEquals(response.resultCode, SUCCESS);
 }
 
 @test:Config {
-   dependsOn: [testUpdateUserWithNullValues]
+    dependsOn: [testUpdateUserWithNullValues]
 }
 public function testGetUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   UserConfig value = check ldapClient->getEntry(userDN);
-   test:assertEquals(value?.sn, "Updated User");
+    Client ldapClient = check validateClient(ldap);
+    UserConfig value = check ldapClient->getEntry(userDN);
+    test:assertEquals(value?.sn, "Updated User");
 }
 
 @test:Config {}
 public function testInvalidClient() returns error? {
-   Client|Error ldapClient = new ({
-       hostName: "111.111.11.111",
-       port: port,
-       domainName: domainName,
-       password: password
-   });
-   test:assertTrue(ldapClient is Error);
+    Client|Error ldapClient = new ({
+        hostName: "111.111.11.111",
+        port: port,
+        domainName: domainName,
+        password: password
+    });
+    test:assertTrue(ldapClient is Error);
 }
 
 @test:Config {}
 public function testInvalidDomainInClient() {
-   Client|Error ldapClient = new ({
-       hostName: hostName,
-       port: port,
-       domainName: "invalid@ad.invalid",
-       password: password
-   });
-   test:assertTrue(ldapClient is Error);
+    Client|Error ldapClient = new ({
+        hostName: hostName,
+        port: port,
+        domainName: "invalid@ad.invalid",
+        password: password
+    });
+    test:assertTrue(ldapClient is Error);
 }
 
 @test:Config {}
 public function testGetInvalidUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   UserConfig|Error value = ldapClient->getEntry("CN=Invalid User,dc=mycompany,dc=com");
-   test:assertTrue(value is Error);
+    Client ldapClient = check validateClient(ldap);
+    UserConfig|Error value = ldapClient->getEntry("CN=Invalid User,dc=mycompany,dc=com");
+    test:assertTrue(value is Error);
 }
 
 @test:Config {
-   dependsOn: [testUpdateUser]
+    dependsOn: [testUpdateUser]
 }
 public function testUpdateUserWithNullValues() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->modify(userDN, updateUser);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->modify(userDN, updateUser);
+    test:assertEquals(response.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testAddUserWithNullValues() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testCompareAttributeValues() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   boolean compare = check ldapClient->compare("CN=Test User1,dc=mycompany,dc=com", "sn", "Timothy");
-   test:assertEquals(compare, true);
+    boolean compare = check ldapClient->compare("CN=Test User1,dc=mycompany,dc=com", "sn", "Timothy");
+    test:assertEquals(compare, true);
 
-   LdapResponse modifyDN = check ldapClient->modifyDn("CN=Test User1,dc=mycompany,dc=com", "CN=Test User2", true);
-   test:assertEquals(modifyDN.resultCode, SUCCESS);
+    LdapResponse modifyDN = check ldapClient->modifyDn("CN=Test User1,dc=mycompany,dc=com", "CN=Test User2", true);
+    test:assertEquals(modifyDN.resultCode, SUCCESS);
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User2,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User2,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testSearchWithType() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
-   test:assertEquals(value.length(), 1);
-   test:assertEquals(value[0].objectClass, ["person", "top"]);
+    UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertEquals(value.length(), 1);
+    test:assertEquals(value[0].objectClass, ["person", "top"]);
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testSearchUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   SearchResult value = check ldapClient->search("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
-   test:assertEquals(value.resultCode, SUCCESS);
-   test:assertEquals((<Entry[]>value.entries).length(), 1);
-   test:assertEquals((<Entry[]>value.entries)[0]["objectClass"], ["person", "top"]);
-   test:assertTrue(value?.searchReferences is ());
+    SearchResult value = check ldapClient->search("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertEquals(value.resultCode, SUCCESS);
+    test:assertEquals((<Entry[]>value.entries).length(), 1);
+    test:assertEquals((<Entry[]>value.entries)[0]["objectClass"], ["person", "top"]);
+    test:assertTrue(value?.searchReferences is ());
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testSearchNonExistingUsers() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   SearchResult|Error value = ldapClient->search("dc=mycompany,dc=com", "(givenName=Non existent)", SUB);
-   test:assertTrue(value is Error);
-   if value is Error {
-       ErrorDetails errorDetails = value.detail();
-       test:assertEquals(errorDetails.resultCode, OTHER);
-   }
+    SearchResult|Error value = ldapClient->search("dc=mycompany,dc=com", "(givenName=Non existent)", SUB);
+    test:assertTrue(value is Error);
+    if value is Error {
+        ErrorDetails errorDetails = value.detail();
+        test:assertEquals(errorDetails.resultCode, OTHER);
+    }
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testAddingUserWithClosedClient() returns error? {
-   Client ldapClient1 = check new ({
-       hostName: hostName,
-       port: port,
-       domainName: domainName,
-       password: password
-   });
-   ldapClient1->close();
-   boolean isConnected = ldapClient1->isConnected();
-   test:assertTrue(!isConnected);
-   LdapResponse|Error response = ldapClient1->add("CN=Test User12,dc=mycompany,dc=com", user);
-   test:assertTrue(response is Error);
-   if response is Error {
-       ErrorDetails errorDetails = response.detail();
-       test:assertEquals(errorDetails.resultCode, OTHER);
-   }
+    Client ldapClient1 = check new ({
+        hostName: hostName,
+        port: port,
+        domainName: domainName,
+        password: password
+    });
+    ldapClient1->close();
+    boolean isConnected = ldapClient1->isConnected();
+    test:assertTrue(!isConnected);
+    LdapResponse|Error response = ldapClient1->add("CN=Test User12,dc=mycompany,dc=com", user);
+    test:assertTrue(response is Error);
+    if response is Error {
+        ErrorDetails errorDetails = response.detail();
+        test:assertEquals(errorDetails.resultCode, OTHER);
+    }
 }
 
 @test:Config {}
 public function testModifyingUserWithClosedClient() returns error? {
-   Client ldapClient1 = check new ({
-       hostName: hostName,
-       port: port,
-       domainName: domainName,
-       password: password
-   });
-   ldapClient1->close();
-   boolean isConnected = ldapClient1->isConnected();
-   test:assertTrue(!isConnected);
-   LdapResponse|Error response = ldapClient1->modify(userDN, updateUser);
-   test:assertTrue(response is Error);
-   if response is Error {
-       ErrorDetails errorDetails = response.detail();
-       test:assertEquals(errorDetails.resultCode, OTHER);
-   }
+    Client ldapClient1 = check new ({
+        hostName: hostName,
+        port: port,
+        domainName: domainName,
+        password: password
+    });
+    ldapClient1->close();
+    boolean isConnected = ldapClient1->isConnected();
+    test:assertTrue(!isConnected);
+    LdapResponse|Error response = ldapClient1->modify(userDN, updateUser);
+    test:assertTrue(response is Error);
+    if response is Error {
+        ErrorDetails errorDetails = response.detail();
+        test:assertEquals(errorDetails.resultCode, OTHER);
+    }
 }
 
 @test:Config {}
 public function testModifyDN() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   LdapResponse modifyDN = check ldapClient->modifyDn("CN=Test User1,dc=mycompany,dc=com", "CN=Test User2", true);
-   test:assertEquals(modifyDN.resultCode, SUCCESS);
+    LdapResponse modifyDN = check ldapClient->modifyDn("CN=Test User1,dc=mycompany,dc=com", "CN=Test User2", true);
+    test:assertEquals(modifyDN.resultCode, SUCCESS);
 
-   LdapResponse delete = check ldapClient->delete("CN=Test User2,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    LdapResponse delete = check ldapClient->delete("CN=Test User2,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
 public function testModifyDnInNonExistingUser() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse|Error modifyDN = ldapClient->modifyDn("CN=Non Existing User,dc=mycompany,dc=com", "CN=Test User2", true);
-   test:assertTrue(modifyDN is Error);
-   if modifyDN is Error {
-       ErrorDetails errorDetails = modifyDN.detail();
-       test:assertEquals(errorDetails.resultCode, NO_SUCH_OBJECT);
-   }
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse|Error modifyDN = ldapClient->modifyDn("CN=Non Existing User,dc=mycompany,dc=com", "CN=Test User2", true);
+    test:assertTrue(modifyDN is Error);
+    if modifyDN is Error {
+        ErrorDetails errorDetails = modifyDN.detail();
+        test:assertEquals(errorDetails.resultCode, NO_SUCH_OBJECT);
+    }
 }
 
 @test:Config {}
 public function testSearchWithInvalidType() returns error? {
-   Client ldapClient = check validateClient(ldap);
-   LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
-   test:assertEquals(response.resultCode, SUCCESS);
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User1,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
 
-   record {|string id;|}[]|Error value = ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
-   test:assertTrue(value is Error);
-   test:assertEquals((<Error>value).message(), "{ballerina}ConversionError");
-   LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
-   test:assertEquals(delete.resultCode, SUCCESS);
+    record {|string id;|}[]|Error value = ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertTrue(value is Error);
+    test:assertEquals((<Error>value).message(), "{ballerina}ConversionError");
+    LdapResponse delete = check ldapClient->delete("CN=Test User1,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }
 
-@test:Config{}
+@test:Config {}
 public function testTlsConnection() returns error? {
-   ClientSecureSocket clientSecureSocket = {
-      cert: "tests/resources/server/certs/server.crt",
-      enable: true
-   };
+    ClientSecureSocket clientSecureSocket = {
+        cert: "tests/resources/server/certs/server.crt",
+        enable: true
+    };
 
-   Client ldapClient =  check new ({
-      port: 636,
-      hostName,
-      password,
-      domainName,
-      clientSecureSocket
-   });
+    Client ldapClient = check new ({
+        port: 636,
+        hostName,
+        password,
+        domainName,
+        clientSecureSocket
+    });
 
-   boolean isConnected = ldapClient->isConnected();
-   test:assertTrue(isConnected);
+    boolean isConnected = ldapClient->isConnected();
+    test:assertTrue(isConnected);
 }
 
-@test:Config{}
+@test:Config {}
 public function testTlsConnectionWithInvalidCert() returns error? {
-   ClientSecureSocket clientSecureSocket = {
-      cert: "tests/resources/server/certs/invalid.crt",
-      enable: true
-   };
+    ClientSecureSocket clientSecureSocket = {
+        cert: "tests/resources/server/certs/invalid.crt",
+        enable: true
+    };
 
-   Client|Error ldapClient =  new ({
-      port: 636,
-      hostName,
-      password,
-      domainName,
-      clientSecureSocket
-   });
+    Client|Error ldapClient = new ({
+        port: 636,
+        hostName,
+        password,
+        domainName,
+        clientSecureSocket
+    });
 
-   test:assertTrue(ldapClient is Error);
+    test:assertTrue(ldapClient is Error);
 }
 
-@test:Config{}
+@test:Config {}
 public function testTlsConnectionWithTrustStore() returns error? {
-   ClientSecureSocket clientSecureSocket = {
-         cert: {
-               path: "tests/resources/server/certs/truststore.p12",
-               password: "password"
-         }
-   };
+    ClientSecureSocket clientSecureSocket = {
+        cert: {
+            path: "tests/resources/server/certs/truststore.p12",
+            password: "password"
+        }
+    };
 
-   Client ldapClient =  check new ({
-      port: 636,
-      hostName,
-      password,
-      domainName,
-      clientSecureSocket
-   });
+    Client ldapClient = check new ({
+        port: 636,
+        hostName,
+        password,
+        domainName,
+        clientSecureSocket
+    });
 
-   boolean isConnected = ldapClient->isConnected();
-   test:assertTrue(isConnected);
+    boolean isConnected = ldapClient->isConnected();
+    test:assertTrue(isConnected);
+}
+
+@test:Config {}
+public function testGetEntryWithSelectiveAttributes() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User3,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Get entry with selective attributes (only sn and cn)
+    UserConfig value = check ldapClient->getEntry("CN=Test User3,dc=mycompany,dc=com", ["sn", "cn"]);
+    test:assertEquals(value?.sn, "Timothy");
+    test:assertEquals(value?.cn, "Test User3");
+    // objectClass should be nil as it was not requested
+    test:assertTrue(value?.objectClass is ());
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User3,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testGetEntryWithAllAttributes() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User4,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Get entry with all attributes (passing empty array or nil)
+    UserConfig value = check ldapClient->getEntry("CN=Test User4,dc=mycompany,dc=com");
+    test:assertEquals(value?.sn, "Timothy");
+    test:assertEquals(value?.cn, "Test User4");
+    test:assertEquals(value?.objectClass, ["person", "top"]);
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User4,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testGetEntryWithSingleAttribute() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User5,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Get entry with only one attribute
+    UserConfig value = check ldapClient->getEntry("CN=Test User5,dc=mycompany,dc=com", ["sn"]);
+    test:assertEquals(value?.sn, "Timothy");
+    // Other attributes should be nil
+    test:assertTrue(value?.cn is ());
+    test:assertTrue(value?.objectClass is ());
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User5,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testSearchWithTypeWithSelectiveAttributes() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User6,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Search with selective attributes - attributes are automatically extracted from UserConfig type
+    UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertTrue(value.length() > 0);
+    test:assertEquals(value[0].sn, "Timothy");
+    test:assertTrue(value[0].cn is string);
+    // Only attributes defined in UserConfig type will be retrieved
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User6,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testSearchWithTypeWithAllAttributes() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User7,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Search with all attributes - attributes are automatically extracted from UserConfig type
+    UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertTrue(value.length() > 0);
+    test:assertEquals(value[0].sn, "Timothy");
+    test:assertEquals(value[0].objectClass, ["person", "top"]);
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User7,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testSearchWithSelectiveAttributes() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User8,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Search with selective attributes
+    SearchResult value = check ldapClient->search("dc=mycompany,dc=com", "(sn=Timothy)", SUB, ["sn", "cn"]);
+    test:assertEquals(value.resultCode, SUCCESS);
+    test:assertTrue((<Entry[]>value.entries).length() > 0);
+    Entry firstEntry = (<Entry[]>value.entries)[0];
+    test:assertTrue(firstEntry["sn"] is string);
+    test:assertTrue(firstEntry["cn"] is string);
+    // objectClass should not be present as it was not requested
+    test:assertTrue(firstEntry["objectClass"] is ());
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User8,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testSearchWithAllAttributes() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User9,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Search with all attributes
+    SearchResult value = check ldapClient->search("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    test:assertEquals(value.resultCode, SUCCESS);
+    test:assertTrue((<Entry[]>value.entries).length() > 0);
+    Entry firstEntry = (<Entry[]>value.entries)[0];
+    test:assertEquals(firstEntry["objectClass"], ["person", "top"]);
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User9,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testGetEntryWithInvalidAttribute() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User10,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Get entry with invalid attribute name - LDAP should not return an error, just won't include that attribute
+    UserConfig value = check ldapClient->getEntry("CN=Test User10,dc=mycompany,dc=com", ["sn", "invalidAttribute"]);
+    test:assertEquals(value?.sn, "Timothy");
+    test:assertTrue(value?.cn is ());
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User10,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
 }

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -423,10 +423,10 @@ public function testSearchWithTypeAutoAttributeExtraction() returns error? {
     test:assertEquals(response.resultCode, SUCCESS);
 
     // Validates that searchWithType automatically extracts and retrieves attributes from UserConfig type
-    UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
+    record{|string sn; string cn;|}[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
     test:assertTrue(value.length() > 0);
     test:assertEquals(value[0].sn, "Timothy");
-    test:assertTrue(value[0].cn is string);
+    test:assertEquals(value[0].cn, "Test User6");
 
     LdapResponse delete = check ldapClient->delete("CN=Test User6,dc=mycompany,dc=com");
     test:assertEquals(delete.resultCode, SUCCESS);
@@ -507,10 +507,10 @@ public function testGetEntryWithTypeIntrospection() returns error? {
     test:assertEquals(response.resultCode, SUCCESS);
 
     // Get entry without explicit attributes - should use type introspection to determine attributes
-    UserConfig value = check ldapClient->getEntry("CN=Test User11,dc=mycompany,dc=com");
-    test:assertEquals(value?.sn, "Timothy");
-    test:assertEquals(value?.cn, "Test User11");
-    test:assertEquals(value?.objectClass, ["person", "top"]);
+    record {| string sn; string cn; string[] objectClass;|} value = check ldapClient->getEntry("CN=Test User11,dc=mycompany,dc=com");
+    test:assertEquals(value.sn, "Timothy");
+    test:assertEquals(value.cn, "Test User11");
+    test:assertEquals(value.objectClass, ["person", "top"]);
 
     LdapResponse delete = check ldapClient->delete("CN=Test User11,dc=mycompany,dc=com");
     test:assertEquals(delete.resultCode, SUCCESS);

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -582,6 +582,10 @@ public function testGetEntryExplicitAttributesOverrideType() returns error? {
     test:assertTrue(value?.objectClass is ());
 
     LdapResponse delete = check ldapClient->delete("CN=Test User15,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
 public function testMultiValueAttributeWithNonAscii() returns error? {
     Client ldapClient = check validateClient(ldap);
 

--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -417,29 +417,28 @@ public function testGetEntryWithSingleAttribute() returns error? {
 }
 
 @test:Config {}
-public function testSearchWithTypeWithSelectiveAttributes() returns error? {
+public function testSearchWithTypeAutoAttributeExtraction() returns error? {
     Client ldapClient = check validateClient(ldap);
     LdapResponse response = check ldapClient->add("CN=Test User6,dc=mycompany,dc=com", user);
     test:assertEquals(response.resultCode, SUCCESS);
 
-    // Search with selective attributes - attributes are automatically extracted from UserConfig type
+    // Validates that searchWithType automatically extracts and retrieves attributes from UserConfig type
     UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
     test:assertTrue(value.length() > 0);
     test:assertEquals(value[0].sn, "Timothy");
     test:assertTrue(value[0].cn is string);
-    // Only attributes defined in UserConfig type will be retrieved
 
     LdapResponse delete = check ldapClient->delete("CN=Test User6,dc=mycompany,dc=com");
     test:assertEquals(delete.resultCode, SUCCESS);
 }
 
 @test:Config {}
-public function testSearchWithTypeWithAllAttributes() returns error? {
+public function testSearchWithTypeValidateAllFields() returns error? {
     Client ldapClient = check validateClient(ldap);
     LdapResponse response = check ldapClient->add("CN=Test User7,dc=mycompany,dc=com", user);
     test:assertEquals(response.resultCode, SUCCESS);
 
-    // Search with all attributes - attributes are automatically extracted from UserConfig type
+    // Validates that all fields defined in UserConfig type are correctly populated by automatic attribute extraction
     UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(sn=Timothy)", SUB);
     test:assertTrue(value.length() > 0);
     test:assertEquals(value[0].sn, "Timothy");
@@ -498,5 +497,90 @@ public function testGetEntryWithInvalidAttribute() returns error? {
     test:assertTrue(value?.cn is ());
 
     LdapResponse delete = check ldapClient->delete("CN=Test User10,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testGetEntryWithTypeIntrospection() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User11,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Get entry without explicit attributes - should use type introspection to determine attributes
+    UserConfig value = check ldapClient->getEntry("CN=Test User11,dc=mycompany,dc=com");
+    test:assertEquals(value?.sn, "Timothy");
+    test:assertEquals(value?.cn, "Test User11");
+    test:assertEquals(value?.objectClass, ["person", "top"]);
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User11,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testSearchWithTypeExplicitAttributes() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User12,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Search with explicit attributes parameter in searchWithType - should override type-inferred attributes
+    UserConfig[] value = check ldapClient->searchWithType("dc=mycompany,dc=com", "(cn=Test User12)", SUB, ["sn", "cn"]);
+    test:assertEquals(value.length(), 1);
+    test:assertEquals(value[0].sn, "Timothy");
+    test:assertEquals(value[0].cn, "Test User12");
+    // objectClass should be nil as it was not in the explicit attributes list
+    test:assertTrue(value[0].objectClass is ());
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User12,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testGetEntryWithRecordHavingRestField() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User13,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Get entry with a record type that has a rest field - should retrieve all attributes
+    Entry value = check ldapClient->getEntry("CN=Test User13,dc=mycompany,dc=com");
+    test:assertEquals(value["sn"], "Timothy");
+    test:assertEquals(value["cn"], "Test User13");
+    test:assertEquals(value["objectClass"], ["person", "top"]);
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User13,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testSearchWithEmptyAttributesArray() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User14,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Search with empty array should retrieve all attributes
+    SearchResult value = check ldapClient->search("dc=mycompany,dc=com", "(cn=Test User14)", SUB, []);
+    test:assertEquals(value.resultCode, SUCCESS);
+    test:assertTrue((<Entry[]>value.entries).length() > 0);
+    Entry firstEntry = (<Entry[]>value.entries)[0];
+    test:assertEquals(firstEntry["objectClass"], ["person", "top"]);
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User14,dc=mycompany,dc=com");
+    test:assertEquals(delete.resultCode, SUCCESS);
+}
+
+@test:Config {}
+public function testGetEntryExplicitAttributesOverrideType() returns error? {
+    Client ldapClient = check validateClient(ldap);
+    LdapResponse response = check ldapClient->add("CN=Test User15,dc=mycompany,dc=com", user);
+    test:assertEquals(response.resultCode, SUCCESS);
+
+    // Get entry with explicit attributes that differ from UserConfig type fields
+    // Should use explicit attributes and ignore type-inferred attributes
+    UserConfig value = check ldapClient->getEntry("CN=Test User15,dc=mycompany,dc=com", ["cn"]);
+    test:assertEquals(value?.cn, "Test User15");
+    // sn and objectClass should be nil as they were not in the explicit attributes list
+    test:assertTrue(value?.sn is ());
+    test:assertTrue(value?.objectClass is ());
+
+    LdapResponse delete = check ldapClient->delete("CN=Test User15,dc=mycompany,dc=com");
     test:assertEquals(delete.resultCode, SUCCESS);
 }

--- a/ballerina/tests/types.bal
+++ b/ballerina/tests/types.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-type UserConfig record {
+type UserConfig record {|
     *Person;
     string userPrincipalName?;
     string givenName?;
@@ -37,7 +37,8 @@ type UserConfig record {
     string distinguishedName?;
     string manager?;
     string userAccountControl?;
-};
+    AttributeType...;
+|};
 
 record {|AttributeType...;|} user = {
     "sn": "Timothy",

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -119,14 +119,13 @@ public type Entry record{|AttributeType...;|};
 # + cn - common name of the person
 # + userPassword - password of the person
 # + telephoneNumber - telephone number of the person
-public type Person record {|
+public type Person record {
     string|string[]|ObjectClass|ObjectClass[] objectClass?;
     string sn?;
     string cn?;
     string userPassword?;
     string telephoneNumber?;
-    AttributeType...;
-|};
+};
 
 # Standard values for ObjectClass attribute type.
 public enum ObjectClass {

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -119,13 +119,14 @@ public type Entry record{|AttributeType...;|};
 # + cn - common name of the person
 # + userPassword - password of the person
 # + telephoneNumber - telephone number of the person
-public type Person record {
+public type Person record {|
     string|string[]|ObjectClass|ObjectClass[] objectClass?;
     string sn?;
     string cn?;
     string userPassword?;
     string telephoneNumber?;
-};
+    AttributeType...;
+|};
 
 # Standard values for ObjectClass attribute type.
 public enum ObjectClass {

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,19 @@
+# Changelog
+
+This file contains all the notable changes done to the Ballerina LDAP package through the releases.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- [Add support for selective attribute retrieval in LDAP client's get and search methods](https://github.com/ballerina-platform/ballerina-library/issues/8563)
+  - Added optional `attributes` parameter to `getEntry()` method to allow specifying which attributes to retrieve
+  - Added optional `attributes` parameter to `search()` method to allow selective attribute retrieval in search operations
+  - Enhanced `searchWithType()` method to automatically extract and retrieve only the attributes defined in the target record type, providing type-safe selective attribute retrieval
+  - This improvement is particularly useful for Active Directory use cases where retrieving specific attributes is more efficient than fetching all attributes
+
+### Changed
+
+### Fixed

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -209,13 +209,19 @@ Gets information of an entry from the directory server.
 # Gets information of an entry.
 #
 # + dN - The distinguished name of the entry
-# + attributes - Optional array of attribute names to retrieve. If not provided, all attributes are retrieved
+# + attributes - Optional array of attribute names to retrieve. If not provided, attributes are determined based on the target type
 # + targetType - Default parameter use to infer the user specified type
 # + return - An entry result with the given type or else `ldap:Error`
-remote isolated function getEntry(string dN, string[]? attributes = (), typedesc<anydata> targetType = <>) returns targetType|Error;
+remote isolated function getEntry(string dN, string[]? attributes = (), typedesc<Entry> targetType = <>) returns targetType|Error;
 ```
 
-The `attributes` parameter allows for selective attribute retrieval. When specific attribute names are provided in the array, only those attributes will be included in the response. This is particularly useful for Active Directory scenarios where you may want to retrieve only specific attributes rather than all attributes, improving performance and reducing network overhead. When `attributes` is `nil` or not provided, all user attributes are returned.
+The `attributes` parameter allows for selective attribute retrieval in two ways:
+
+1. **Explicit attributes**: When specific attribute names are provided in the array, only those attributes will be retrieved from LDAP and included in the response. This takes precedence over type-inferred attributes.
+
+2. **Type-inferred attributes**: When `attributes` is `nil` or not provided, the operation automatically extracts attribute names from the target record type definition. For example, if the target type is a record with fields `sn`, `cn`, and `objectClass`, only those three attributes will be retrieved. If the target type has a rest field (e.g., `record {|string...;|}`), all user attributes are retrieved since the exact attributes cannot be determined from the type.
+
+This feature is particularly useful for Active Directory scenarios where directory entries may have numerous attributes, allowing you to retrieve only the attributes you need, thereby improving performance and reducing network overhead.
 
 ### 3.6 Search operation
 
@@ -234,7 +240,7 @@ remote isolated function search(string baseDn, string filter, SearchScope scope,
 
 The `attributes` parameter allows for selective attribute retrieval, which is particularly useful for Active Directory scenarios where you may want to retrieve only specific attributes rather than all attributes. When `attributes` is `nil` or an empty array, all user attributes are returned. When specific attribute names are provided, only those attributes will be included in the response.
 
-### 3.6 Search with type operation
+### 3.7 Search with type operation
 
 Returns a list of entries that match the given search parameters.
 
@@ -244,12 +250,19 @@ Returns a list of entries that match the given search parameters.
 # + baseDn - The base distinguished name of the entry
 # + filter - The filter to be used in the search
 # + scope - The scope of the search
-# + targetType - Default parameter use to infer the user specified type. The attributes to retrieve are automatically determined from the record type fields
+# + attributes - Optional array of attribute names to retrieve. If not provided, attributes are determined based on the target type
+# + targetType - Default parameter use to infer the user specified type
 # + return - An array of entries with the given type or else `ldap:Error`
-remote isolated function searchWithType(string baseDn, string filter, SearchScope scope, typedesc<record{}[]> targetType = <>) returns targetType|Error;
+remote isolated function searchWithType(string baseDn, string filter, SearchScope scope, string[]? attributes = (), typedesc<record {}[]> targetType = <>) returns targetType|Error;
 ```
 
-The `searchWithType` operation automatically extracts the attribute names from the target record type and retrieves only those attributes from the LDAP directory. This provides an efficient and type-safe way to perform selective attribute retrieval without explicitly specifying the attributes list. For example, if you specify a return type like `UserConfig[]` where `UserConfig` has fields `sn`, `cn`, and `objectClass`, only those three attributes will be retrieved from LDAP, improving performance and reducing network overhead. This is particularly beneficial for Active Directory use cases where directory entries may have numerous attributes.
+The `searchWithType` operation provides flexible selective attribute retrieval in two ways:
+
+1. **Explicit attributes**: When specific attribute names are provided in the `attributes` parameter, only those attributes will be retrieved from LDAP. This takes precedence over type-inferred attributes and allows you to retrieve a different set of attributes than what's defined in the target type.
+
+2. **Type-inferred attributes**: When `attributes` is `nil` or not provided, the operation automatically extracts the attribute names from the target record type definition and retrieves only those attributes from the LDAP directory. For example, if you specify a return type like `UserConfig[]` where `UserConfig` has fields `sn`, `cn`, and `objectClass`, only those three attributes will be retrieved from LDAP. If the target record type has a rest field, all user attributes are retrieved since the exact attributes cannot be determined from the type.
+
+This provides an efficient and type-safe way to perform selective attribute retrieval without explicitly specifying the attributes list in most cases, while still allowing explicit control when needed. This is particularly beneficial for Active Directory use cases where directory entries may have numerous attributes, improving performance and reducing network overhead.
 
 ### 3.7.1 Search scope
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Authors_: @Nuvindu \
 _Reviewers_: @NipunaRanasinghe @ayeshLK @DimuthuMadushan \
 _Created_: 2024/08/11 \
-_Updated_: 2024/08/11 \
+_Updated_: 2026/01/19 \
 _Edition_: Swan Lake
 
 ## Introduction
@@ -35,9 +35,10 @@ The conforming implementation of the specification is released and included in t
     * 3.2 [Modify operation](#32-modify-operation)
     * 3.3 [ModifyDN operation](#33-modifydn-operation)
     * 3.4 [Compare operation](#34-compare-operation)
-    * 3.5 [Search operation](#35-search-operation)
-    * 3.6 [Search with type operation](#36-search-with-type-operation)
-    * 3.7 [Delete operation](#37-delete-operation)
+    * 3.5 [Get operation](#35-get-operation)
+    * 3.6 [Search operation](#36-search-operation)
+    * 3.7 [Search with type operation](#37-search-with-type-operation)
+    * 3.8 [Delete operation](#38-delete-operation)
 
 ## 1. Overview
 
@@ -200,7 +201,23 @@ Determines whether a given entry has a specified attribute value.
 remote isolated function compare(string dN, string attributeName, string assertionValue) returns boolean|Error;
 ```
 
-### 3.5 Search operation
+### 3.5 Get operation
+
+Gets information of an entry from the directory server.
+
+```ballerina
+# Gets information of an entry.
+#
+# + dN - The distinguished name of the entry
+# + attributes - Optional array of attribute names to retrieve. If not provided, all attributes are retrieved
+# + targetType - Default parameter use to infer the user specified type
+# + return - An entry result with the given type or else `ldap:Error`
+remote isolated function getEntry(string dN, string[]? attributes = (), typedesc<anydata> targetType = <>) returns targetType|Error;
+```
+
+The `attributes` parameter allows for selective attribute retrieval. When specific attribute names are provided in the array, only those attributes will be included in the response. This is particularly useful for Active Directory scenarios where you may want to retrieve only specific attributes rather than all attributes, improving performance and reducing network overhead. When `attributes` is `nil` or not provided, all user attributes are returned.
+
+### 3.6 Search operation
 
 Returns a record containing search result entries and references that match the given search parameters.
 
@@ -210,9 +227,12 @@ Returns a record containing search result entries and references that match the 
 # + baseDn - The base distinguished name of the entry
 # + filter - The filter to be used in the search
 # + scope - The scope of the search
+# + attributes - Optional array of attribute names to retrieve. If not provided, all attributes are retrieved
 # + return - An `ldap:SearchResult` if successful, or else `ldap:Error`
-remote isolated function search(string baseDn, string filter, SearchScope scope) returns SearchResult|Error;
+remote isolated function search(string baseDn, string filter, SearchScope scope, string[]? attributes = ()) returns SearchResult|Error;
 ```
+
+The `attributes` parameter allows for selective attribute retrieval, which is particularly useful for Active Directory scenarios where you may want to retrieve only specific attributes rather than all attributes. When `attributes` is `nil` or an empty array, all user attributes are returned. When specific attribute names are provided, only those attributes will be included in the response.
 
 ### 3.6 Search with type operation
 
@@ -224,12 +244,14 @@ Returns a list of entries that match the given search parameters.
 # + baseDn - The base distinguished name of the entry
 # + filter - The filter to be used in the search
 # + scope - The scope of the search
-# + targetType - Default parameter use to infer the user specified type
+# + targetType - Default parameter use to infer the user specified type. The attributes to retrieve are automatically determined from the record type fields
 # + return - An array of entries with the given type or else `ldap:Error`
 remote isolated function searchWithType(string baseDn, string filter, SearchScope scope, typedesc<record{}[]> targetType = <>) returns targetType|Error;
 ```
 
-### 3.6.1 Search scope
+The `searchWithType` operation automatically extracts the attribute names from the target record type and retrieves only those attributes from the LDAP directory. This provides an efficient and type-safe way to perform selective attribute retrieval without explicitly specifying the attributes list. For example, if you specify a return type like `UserConfig[]` where `UserConfig` has fields `sn`, `cn`, and `objectClass`, only those three attributes will be retrieved from LDAP, improving performance and reducing network overhead. This is particularly beneficial for Active Directory use cases where directory entries may have numerous attributes.
+
+### 3.7.1 Search scope
 
 The `ldap:SearchScope` defines the part of the target subtree that should be included in the search.
 
@@ -251,11 +273,11 @@ public enum SearchScope {
 };
 ```
 
-### 3.6.2 Search filter
+### 3.7.2 Search filter
 
 Filters are essential for specifying the criteria used to locate entries in search requests. [Learn more](https://ldap.com/ldap-filters/).
 
-### 3.7 Delete operation
+### 3.8 Delete operation
 
 Removes an entry from a directory server.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.3.1-SNAPSHOT
+version=1.4.0-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 
 checkstylePluginVersion=10.12.0

--- a/native/src/main/java/io/ballerina/lib/ldap/Client.java
+++ b/native/src/main/java/io/ballerina/lib/ldap/Client.java
@@ -323,12 +323,14 @@ public final class Client {
         });
     }
 
-    public static Object getEntry(BObject ldapClient, BString dN, BTypedesc typeParam) {
+    public static Object getEntry(BObject ldapClient, BString dN, Object attributesArray, BTypedesc typeParam) {
         BMap<BString, Object> entry = ValueCreator.createMapValue();
         try {
             LDAPConnection ldapConnection = (LDAPConnection) ldapClient.getNativeData(NATIVE_CLIENT);
             validateConnection(ldapConnection);
-            SearchResultEntry userEntry = ldapConnection.getEntry(dN.getValue());
+            SearchResultEntry userEntry;
+            String[] attributes = getAttributesArray(attributesArray);
+            userEntry = ldapConnection.getEntry(dN.getValue(), attributes);
             if (Objects.isNull(userEntry)) {
                 return Utils.createError(String.format(ENTRY_NOT_FOUND, dN), new LDAPException(NO_SUCH_OBJECT));
             }
@@ -341,7 +343,8 @@ public final class Client {
         }
     }
 
-    public static Object search(Environment env, BObject ldapClient, BString baseDn, BString filter, BString scope) {
+    public static Object search(Environment env, BObject ldapClient, BString baseDn, BString filter, BString scope,
+            Object attributesArray) {
         return env.yieldAndRun(() -> {
             CompletableFuture<Object> future = new CompletableFuture<>();
             try {
@@ -349,8 +352,10 @@ public final class Client {
                 LDAPConnection ldapConnection = (LDAPConnection) ldapClient.getNativeData(NATIVE_CLIENT);
                 validateConnection(ldapConnection);
                 SearchResultListener searchResultListener = new CustomSearchResultListener(future, baseDn.getValue());
-                SearchRequest searchRequest = new SearchRequest(searchResultListener, baseDn.getValue(),
-                        searchScope, filter.getValue());
+                SearchRequest searchRequest;
+                String[] attributes = getAttributesArray(attributesArray);
+                searchRequest = new SearchRequest(searchResultListener, baseDn.getValue(),
+                            searchScope, filter.getValue(), attributes);
                 ldapConnection.asyncSearch(searchRequest);
                 return future.get();
             } catch (LDAPException e) {
@@ -359,6 +364,11 @@ public final class Client {
                 return Utils.createError(e.getMessage(), e);
             }
         });
+    }
+
+    private static String[] getAttributesArray(Object attributes) {
+        return (attributes instanceof BArray attributesArray && !attributesArray.isEmpty()) ?
+                attributesArray.getStringArray() : null;
     }
 
     public static Object searchWithType(Environment env, BObject ldapClient, BString baseDn,
@@ -371,8 +381,10 @@ public final class Client {
                 validateConnection(ldapConnection);
                 SearchResultListener searchResultListener = new CustomSearchEntryListener(future, typeParam,
                         baseDn.getValue());
+
+                String[] attributes = Utils.getAttributesFromEntriesType(typeParam);
                 SearchRequest searchRequest = new SearchRequest(searchResultListener, baseDn.getValue(),
-                        searchScope, filter.getValue());
+                        searchScope, filter.getValue(), attributes);
                 ldapConnection.asyncSearch(searchRequest);
                 return future.get();
             } catch (LDAPException e) {

--- a/native/src/main/java/io/ballerina/lib/ldap/Client.java
+++ b/native/src/main/java/io/ballerina/lib/ldap/Client.java
@@ -330,6 +330,9 @@ public final class Client {
             validateConnection(ldapConnection);
             SearchResultEntry userEntry;
             String[] attributes = getAttributesArray(attributesArray);
+            if (attributes == null) {
+                attributes = Utils.getAttributesFromEntryType(typeParam.getDescribingType());
+            }
             userEntry = ldapConnection.getEntry(dN.getValue(), attributes);
             if (Objects.isNull(userEntry)) {
                 return Utils.createError(String.format(ENTRY_NOT_FOUND, dN), new LDAPException(NO_SUCH_OBJECT));
@@ -372,7 +375,8 @@ public final class Client {
     }
 
     public static Object searchWithType(Environment env, BObject ldapClient, BString baseDn,
-                                        BString filter, BString scope, BTypedesc typeParam) {
+                                        BString filter, BString scope, Object attributesArray, 
+                                        BTypedesc typeParam) {
         return env.yieldAndRun(() -> {
             CompletableFuture<Object> future = new CompletableFuture<>();
             try {
@@ -382,7 +386,10 @@ public final class Client {
                 SearchResultListener searchResultListener = new CustomSearchEntryListener(future, typeParam,
                         baseDn.getValue());
 
-                String[] attributes = Utils.getAttributesFromEntriesType(typeParam);
+                String[] attributes = getAttributesArray(attributesArray);
+                if (attributes == null) {
+                    attributes = Utils.getAttributesFromEntriesType(typeParam);
+                }
                 SearchRequest searchRequest = new SearchRequest(searchResultListener, baseDn.getValue(),
                         searchScope, filter.getValue(), attributes);
                 ldapConnection.asyncSearch(searchRequest);

--- a/native/src/main/java/io/ballerina/lib/ldap/Client.java
+++ b/native/src/main/java/io/ballerina/lib/ldap/Client.java
@@ -328,12 +328,11 @@ public final class Client {
         try {
             LDAPConnection ldapConnection = (LDAPConnection) ldapClient.getNativeData(NATIVE_CLIENT);
             validateConnection(ldapConnection);
-            SearchResultEntry userEntry;
             String[] attributes = getAttributesArray(attributesArray);
             if (attributes == null) {
                 attributes = Utils.getAttributesFromEntryType(typeParam.getDescribingType());
             }
-            userEntry = ldapConnection.getEntry(dN.getValue(), attributes);
+            SearchResultEntry userEntry = ldapConnection.getEntry(dN.getValue(), attributes);
             if (Objects.isNull(userEntry)) {
                 return Utils.createError(String.format(ENTRY_NOT_FOUND, dN), new LDAPException(NO_SUCH_OBJECT));
             }
@@ -355,9 +354,8 @@ public final class Client {
                 LDAPConnection ldapConnection = (LDAPConnection) ldapClient.getNativeData(NATIVE_CLIENT);
                 validateConnection(ldapConnection);
                 SearchResultListener searchResultListener = new CustomSearchResultListener(future, baseDn.getValue());
-                SearchRequest searchRequest;
                 String[] attributes = getAttributesArray(attributesArray);
-                searchRequest = new SearchRequest(searchResultListener, baseDn.getValue(),
+                SearchRequest searchRequest = new SearchRequest(searchResultListener, baseDn.getValue(),
                             searchScope, filter.getValue(), attributes);
                 ldapConnection.asyncSearch(searchRequest);
                 return future.get();

--- a/native/src/main/java/io/ballerina/lib/ldap/Utils.java
+++ b/native/src/main/java/io/ballerina/lib/ldap/Utils.java
@@ -240,9 +240,25 @@ public final class Utils {
             return null;
         }
         ArrayType entryArrayType = (ArrayType) entriesType;
-        Type entryType = TypeUtils.getReferredType(entryArrayType.getElementType());
+        return getAttributesFromEntryType(entryArrayType.getElementType());
+    }
+
+    /**
+     * Extracts attribute names from the entry type. The entry type is expected to be a record type.
+     * If the record has a rest field, it is not possible to determine all attribute names. Hence,
+     * null is returned in such cases.
+     * 
+     * @param entryType The Type representing the LDAP entry
+     * @return Array of attribute names, or null if unable to extract
+     */
+    public static String[] getAttributesFromEntryType(Type entryType) {
+        entryType = TypeUtils.getReferredType(entryType);
         if (entryType.getTag() == TypeTags.RECORD_TYPE_TAG) {
-            Map<String, Field> fields = ((RecordType) entryType).getFields();
+            RecordType recordType = (RecordType) entryType;
+            if (recordType.getRestFieldType() != null) {
+                return null;
+            }
+            Map<String, Field> fields = recordType.getFields();
             return fields.keySet().toArray(new String[0]);
         }
         return null;

--- a/native/src/main/java/io/ballerina/lib/ldap/Utils.java
+++ b/native/src/main/java/io/ballerina/lib/ldap/Utils.java
@@ -27,12 +27,17 @@ import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.Field;
+import io.ballerina.runtime.api.types.RecordType;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.TypeTags;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BTypedesc;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -218,5 +223,28 @@ public final class Utils {
                 objectGUID[7], objectGUID[6],
                 objectGUID[8], objectGUID[9],
                 objectGUID[10], objectGUID[11], objectGUID[12], objectGUID[13], objectGUID[14], objectGUID[15]);
+    }
+
+    /**
+     * Extracts attribute names from the type of entries to use for selective LDAP
+     * attribute retrieval.
+     * The entries type is expected to be an array of records. The record represents
+     * the LDAP entry structure.
+     *
+     * @param entriesTypeDesc The BTypedesc containing the type of entries
+     * @return Array of attribute names, or null if unable to extract
+     */
+    public static String[] getAttributesFromEntriesType(BTypedesc entriesTypeDesc) {
+        Type entriesType = TypeUtils.getReferredType(entriesTypeDesc.getDescribingType());
+        if (entriesType.getTag() != TypeTags.ARRAY_TAG) {
+            return null;
+        }
+        ArrayType entryArrayType = (ArrayType) entriesType;
+        Type entryType = TypeUtils.getReferredType(entryArrayType.getElementType());
+        if (entryType.getTag() == TypeTags.RECORD_TYPE_TAG) {
+            Map<String, Field> fields = ((RecordType) entryType).getFields();
+            return fields.keySet().toArray(new String[0]);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
# Description

This PR adds support for selective attribute retrieval in the LDAP client's `getEntry`, `search`, and `searchWithType` methods, addressing the need to retrieve specific attributes from LDAP directory entries rather than always fetching all attributes. This improvement is particularly beneficial for Active Directory use cases where directory entries may contain numerous attributes and retrieving only the required ones improves performance and reduces network overhead.

Fixes [ballerina-platform/ballerina-library#8563](https://github.com/ballerina-platform/ballerina-library/issues/8563)

**Changes Made:**

- **`getEntry()` method**: Added optional `attributes` parameter to allow specifying which attributes to retrieve. When not provided, attributes are automatically extracted from the target record type definition. Supports both explicit attribute specification and type-based introspection.

- **`search()` method**: Added optional `attributes` parameter to enable selective attribute retrieval in search operations. When not provided or set to nil/empty array, all user attributes are retrieved.

- **`searchWithType()` method**: Added optional `attributes` parameter to allow explicit attribute specification. When not provided, the method automatically extracts attribute names from the target record type definition, providing type-safe selective attribute retrieval. Explicit attributes take precedence over type-inferred attributes when both are applicable.

**Implementation Details:**

- Explicit `attributes` parameter takes precedence when provided (overrides type introspection)
- Type introspection automatically extracts field names from record types when attributes not specified
- Record types with rest fields fall back to retrieving all attributes (since exact attributes cannot be determined)
- Added `Utils.getAttributesFromEntryType()` helper method for attribute extraction from record types
- Java native implementation updated in `Client.java` to handle attribute arrays and call appropriate LDAP SDK methods

All parameters are optional and default to `nil`/`()`, ensuring **full backward compatibility** with existing code.

One line release note: 
- Add support for selective attribute retrieval in LDAP client's get and search methods with automatic attribute extraction from record types

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

The following test cases have been added to verify the changes:

**`getEntry()` method tests (7 tests):**
- [x] `testGetEntryWithSelectiveAttributes` - Validates retrieving specific attributes ["sn", "cn"] using `getEntry()` with attributes parameter
- [x] `testGetEntryWithAllAttributes` - Validates default behavior (all attributes) when no attributes parameter is provided
- [x] `testGetEntryWithSingleAttribute` - Tests retrieving a single attribute ["sn"] only
- [x] `testGetEntryWithInvalidAttribute` - Tests graceful handling of invalid/non-existent attribute names
- [x] `testGetEntryWithTypeIntrospection` - Validates automatic attribute extraction from UserConfig type when attributes not provided
- [x] `testGetEntryWithRecordHavingRestField` - Validates that Entry type with rest field retrieves all attributes
- [x] `testGetEntryExplicitAttributesOverrideType` - Validates explicit ["cn"] overrides type-inferred attributes from UserConfig

**`search()` method tests (3 tests):**
- [x] `testSearchWithSelectiveAttributes` - Tests selective attribute retrieval ["sn", "cn"] in `search()` method
- [x] `testSearchWithAllAttributes` - Tests default behavior (all attributes) in `search()` method
- [x] `testSearchWithEmptyAttributesArray` - Tests empty array [] behaves like nil (retrieves all attributes)

**`searchWithType()` method tests (3 tests):**
- [x] `testSearchWithTypeAutoAttributeExtraction` - Validates automatic attribute extraction from UserConfig type
- [x] `testSearchWithTypeValidateAllFields` - Validates that all record type fields are correctly populated
- [x] `testSearchWithTypeExplicitAttributes` - Validates explicit ["sn", "cn"] parameter overrides type-inferred attributes

**Test Configuration**:
* Ballerina Version: Swan Lake Update 12 (2201.12.x)
* Operating System: Linux
* Java SDK: OpenJDK 21

# Checklist:

- [x] Updated the spec
- [x] Update the changelog
- [x] Check for breaking change in BIR level - Could not be able to produce a BIR level change. So the change should be safe

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?